### PR TITLE
After homing set TargetPosition to CurrentPosition to prevent from processing movement

### DIFF
--- a/src/FlexyStepper.cpp
+++ b/src/FlexyStepper.cpp
@@ -771,6 +771,8 @@ bool FlexyStepper::moveToHomeInSteps(long directionTowardHome,
   //
   setCurrentPositionInSteps(0L);    
 
+  setTargetPositionInSteps(0L);
+
   //
   // restore original velocity
   //


### PR DESCRIPTION
Set TargetPosition to CurrentPosition after homing, so if processMovement() is called after homing - no movement is done.